### PR TITLE
Properly parse numbers in condition fields

### DIFF
--- a/userspace/engine/lua/parser.lua
+++ b/userspace/engine/lua/parser.lua
@@ -204,7 +204,7 @@ local G = {
    Hex = (P("0x") + P("0X")) * xdigit ^ 1,
    Expo = S("eE") * S("+-") ^ -1 * digit ^ 1,
    Float = (((digit ^ 1 * P(".") * digit ^ 0) + (P(".") * digit ^ 1)) * V "Expo" ^ -1) + (digit ^ 1 * V "Expo"),
-   Number = C(V "Hex" + V "Float" + V "Int") / function(n)
+   Number = C(V "Hex" + V "Float" + V "Int") * - V "idStart" / function(n)
          return tonumber(n)
       end,
    String = (P '"' * C(((P "\\" * P(1)) + (P(1) - P '"')) ^ 0) * P '"' +


### PR DESCRIPTION
 Falco won't properly parse a rule like this:

    ---
    - rule: Some Rule
      desc: Some Desc
      condition: evt.type=execve and container.image.repository = 271931939120.dkr
      output: Some output
      priority: INFO
    ---

    This is the error when validating the rules:

    Tue Mar 30 12:00:40 2021: Validating rules file(s):
    Tue Mar 30 12:00:40 2021:    /home/mstemm/test.yaml
    1 errors:
    Compilation error when compiling "evt.type=execve and container.image.repository = 271931939120.dkr": 63: syntax error, unexpected 'dkr', expecting 'or', 'and'

    The parsing of the string on the right hand side stops at the period
    before the dkr. The dkr then doesn't match the grammar, resulting in the
    error.

    Looking at the parser implementation more closely, the problem is in the
    definition of "Number":

    ---
    -   Number = C(V "Hex" + V "Float" + V "Int") / function(n)
              return tonumber(n)
           end,
    ---
    Note that it stops after the number, but does not have any requirement
    about what follows.

    This changes the definition of number to require that what follows the
    number is not an identifier character. With this change, values that are
    only numbers are parsed as numbers, and values that start with numbers
    don't match the Number definition and are parsed as BareStrings instead.